### PR TITLE
fix: proper p9 version check, support for >0.10

### DIFF
--- a/patchworklib/patchworklib.py
+++ b/patchworklib/patchworklib.py
@@ -5,17 +5,19 @@ import copy
 import types
 import dill 
 import pickle
-from math import log10 , floor
+import warnings 
+
 import matplotlib
 import matplotlib.font_manager as fm
 import matplotlib.pyplot as plt  
 import matplotlib.axes as axes
-from matplotlib.transforms import Bbox, TransformedBbox, Affine2D
-from matplotlib.offsetbox import AnchoredOffsetbox
-from types import SimpleNamespace as NS
-from contextlib import suppress
-import warnings 
 
+from math import log10 , floor
+from contextlib import suppress
+from pkg_resources import parse_version
+from types import SimpleNamespace as NS
+from matplotlib.offsetbox import AnchoredOffsetbox
+from matplotlib.transforms import Bbox, TransformedBbox, Affine2D
 
 try:
     import patchworklib.modified_grid as mg
@@ -354,7 +356,7 @@ def load_ggplot(ggplot=None, figsize=None):
             gori.theme.themeables['plot_title'].apply(ax)
         
     import plotnine
-    plotnine_version = plotnine.__version__ 
+    plotnine_version = parse_version(plotnine.__version__)
 
     #save_original_position
     global _axes_dict
@@ -400,7 +402,7 @@ def load_ggplot(ggplot=None, figsize=None):
     ggplot._resize_panels()
     
     #Drawing
-    if "0.9" in plotnine_version: 
+    if plotnine_version >= parse_version("0.9.0"): 
         for i, l in enumerate(ggplot.layers, start=1):
             l.zorder = i + 10
             l.draw(ggplot.layout, ggplot.coordinates)
@@ -408,7 +410,7 @@ def load_ggplot(ggplot=None, figsize=None):
         ggplot._draw_watermarks()
         ggplot.theme.apply(ggplot.figure, axs)
     
-    elif "0.8" in plotnine_version:
+    elif plotnine_version >= parse_version("0.8.0"):
         ggplot._draw_layers()
         ggplot._draw_breaks_and_labels()
         ggplot._draw_watermarks()
@@ -423,12 +425,12 @@ def load_ggplot(ggplot=None, figsize=None):
             ax._ggplot_legend = None #For Google colab... 
         ax.change_aspectratio((figsize[0], figsize[1])) 
         
-        if "0.9" in plotnine_version:
+        if plotnine_version >= parse_version("0.9.0"): 
             draw_labels(ax, ggplot, gcp) 
             draw_legend(ax, ggplot, gcp, figsize)
             draw_title(ax,  ggplot, gcp, figsize)
         
-        elif "0.8" in plotnine_version:
+        elif plotnine_version >= parse_version("0.8.0"):
             draw_labels(ax, ggplot, gcp) 
             draw_legend(ax, ggplot, gcp, figsize)
             draw_title(ax,  ggplot, gcp, figsize)


### PR DESCRIPTION
As stated in #25, `patchworklib` doesn't currently support the current `plotnine` release.

The issue in place arises from the way plotnine's version is checked, since my understanding is that `patchworklib` supports `plotnine` releases starting from  `0.8`. The next major release (`0.9`) made some breaking changes which `patchworklib` handles by doing a simple string check to ensure whether the version is 0.8 or 0.9 so as to handle the ggplot drawing. This has, however, two unintended consequences:

(1) Any `plotnine` release newer than `0.9` breaks `patchworklib`.
(2) Any `plotnine` release with substrings containing `0.9` or `0.8` (such as a possible `0.10.8`, for instance) will match the incorrect version and will be handled in the wrong manner.

The fix is pretty trivial, and depends on the `parse_version` function of `pkg_resources`, which is in itself a dependency of `setuptools` that is already a dependency of `patchworklib`, so we aren't adding any extra dependencies.

Comparisons are now made through the properly parsed versions, and any newer versions of `plotnine` should be handled appropiately now.

By the way, thanks for the very useful library!