### PR TITLE
Replace final plotnine version check.

### DIFF
--- a/patchworklib/patchworklib.py
+++ b/patchworklib/patchworklib.py
@@ -456,12 +456,12 @@ def load_ggplot(ggplot=None, figsize=None):
         bricks = Bricks(bricks_dict=bricks_dict) 
         bricks = expand(bricks, width, height)        
         
-        if "0.9" in plotnine_version:
+        if plotnine_version >= parse_version("0.9.0"): 
             draw_labels(bricks, ggplot, gcp) 
             draw_legend(bricks, ggplot, gcp, figsize)
             draw_title(bricks,  ggplot, gcp, figsize)
         
-        elif "0.8" in plotnine_version:
+        elif plotnine_version >= parse_version("0.8.0"):
             draw_labels(bricks, ggplot, gcp) 
             draw_legend(bricks, ggplot, gcp, figsize)
             draw_title(bricks,  ggplot, gcp, figsize)


### PR DESCRIPTION
Based on the work of @AlFontal's commit #26 in response to issue #25, replace the final plotnine version check as it still failed when using plotnine's `facet_grid` and `facet_wrap`.  

The failure can be seen in the 'subplots for plotnine' Colab linked from the ReadMe. 

Colab Result:
![image](https://user-images.githubusercontent.com/62510413/202782100-d135ecc8-a7c2-4944-8d95-385c5c094fc2.png)

The failure can also be reproduced with the example below:
```
import pandas as pd
import patchworklib as pw
import plotnine as p9

df = pd.DataFrame({'a': range(10), 'b': ['x', 'y']*5})

work_around = False
if work_around:
	df1 = df.query('b == "x"')
	g1 = (p9.ggplot(df1, p9.aes(x=df1.index, y='a')) 
		+ p9.geom_line()
		)
	df2 = df.query('b == "y"')
	g2 = (p9.ggplot(df2, p9.aes(x=df2.index, y='a')) 
		+ p9.geom_line()
		)
	
	success1 = pw.load_ggplot(g1)
	success2 = pw.load_ggplot(g2)

	g = success1|success2
	g.savefig('success')
else:
	g = (p9.ggplot(df, p9.aes(x=df.index, y='a', colour='factor(b)')) 
		+ p9.geom_line()
		+ p9.facet_wrap('~b')
		)
	failure = pw.load_ggplot(g)
	# Produces error: Type Error: argument of type 'Version' is not iterable
	print(g)
```

From my testing it now works with `facet_grid` and `facet_wrap`.

Please excuse any incompetence as I am a novice.