### PR TITLE
Enable IPython rich display feature

### DIFF
--- a/patchworklib/patchworklib.py
+++ b/patchworklib/patchworklib.py
@@ -2283,6 +2283,16 @@ class Bricks():
             else:
                 return vstack(other, self, adjust_width=False)
 
+    def _repr_png_(self):
+        buf = io.BytesIO()
+        self.savefig(buf, "png")
+        return buf.getvalue()
+
+    def _repr_pdf_(self):
+        buf = io.BytesIO()
+        self.savefig(buf, "pdf")
+        return buf.getvalue()
+
 class Brick(axes.Axes): 
     """
 
@@ -2874,6 +2884,16 @@ class Brick(axes.Axes):
             else:
                 return vstack(other, self, adjust_width=False)
 
+    def _repr_png_(self):
+        buf = io.BytesIO()
+        self.savefig(buf, "png")
+        return buf.getvalue()
+
+    def _repr_pdf_(self):
+        buf = io.BytesIO()
+        self.savefig(buf, "pdf")
+        return buf.getvalue()
+
 class cBrick(matplotlib.projections.polar.PolarAxes): 
     """
 
@@ -3463,6 +3483,16 @@ class cBrick(matplotlib.projections.polar.PolarAxes):
                 return vstack(_axes_dict[self._parent], other, target=self, direction="b")
             else:
                 return vstack(other, self, adjust_width=False)
+
+    def _repr_png_(self):
+        buf = io.BytesIO()
+        self.savefig(buf, "png")
+        return buf.getvalue()
+
+    def _repr_pdf_(self):
+        buf = io.BytesIO()
+        self.savefig(buf, "pdf")
+        return buf.getvalue()
 
 class spacer():
     def __init__(self, brick=None, value=1.0):


### PR DESCRIPTION
Thanks a lot for creating this amazing package, it is very helpful!

To make displaying plots in Jupyter/Colab notebooks a little easier, I added rich display functions to the various `Brick` objects [[0](https://ipython.readthedocs.io/en/stable/api/generated/IPython.display.html#IPython.display.display),[1](https://ipython.readthedocs.io/en/stable/config/integrating.html#rich-display)].
One now doesn't have to call `savefig()` to see the plot anymore.

What is left to do, is to return appropriate metadata with each `_repr_*_` call to get reasonable plots sizes.
What do you think?