### PR TITLE
Add test including both seaborn and plotnine

### DIFF
--- a/tests/test_patchworklib.py
+++ b/tests/test_patchworklib.py
@@ -37,7 +37,7 @@ def test_sns_and_p9(tmp_path: Path):
 
     g_p9 = pw.load_ggplot(
         (
-            p9.ggplot(titanic, p9.aes(x="sex", y="survived", fill="hue"))
+            p9.ggplot(titanic, p9.aes(x="sex", y="survived", fill="class"))
             + p9.geom_boxplot()
             + p9.ggtitle("plotnine")
         ),

--- a/tests/test_patchworklib.py
+++ b/tests/test_patchworklib.py
@@ -29,15 +29,15 @@ def test_example_plot(tmp_path: Path):
 
 
 def test_sns_and_p9(tmp_path: Path):
-    fmri = sns.load_dataset("fmri")
+    titanic = sns.load_dataset("titanic")
 
     g_sns = pw.Brick(figsize=(4, 4))
-    sns.boxplot(data=fmri, x="sex", y="survived", hue="class", ax=g_sns)
+    sns.boxplot(data=titanic, x="sex", y="survived", hue="class", ax=g_sns)
     g_sns.set_title("seaborn")
 
     g_p9 = pw.load_ggplot(
         (
-            p9.ggplot(fmri, p9.aes(x="sex", y="survived", fill="hue"))
+            p9.ggplot(titanic, p9.aes(x="sex", y="survived", fill="hue"))
             + p9.geom_boxplot()
             + p9.ggtitle("plotnine")
         ),

--- a/tests/test_patchworklib.py
+++ b/tests/test_patchworklib.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+import plotnine as p9
 import seaborn as sns
 
 import patchworklib as pw
@@ -24,4 +25,27 @@ def test_example_plot(tmp_path: Path):
     result_file = tmp_path / "ax12.png"
     ax12 = ax1 | ax2
     ax12.savefig(result_file)
+    assert result_file.exists()
+
+
+def test_sns_and_p9(tmp_path: Path):
+    fmri = sns.load_dataset("fmri")
+
+    g_sns = pw.Brick(figsize=(4, 4))
+    sns.boxplot(data=fmri, x="sex", y="survived", hue="class", ax=g_sns)
+    g_sns.set_title("seaborn")
+
+    g_p9 = pw.load_ggplot(
+        (
+            p9.ggplot(fmri, p9.aes(x="sex", y="survived", fill="hue"))
+            + p9.geom_boxplot()
+            + p9.ggtitle("plotnine")
+        ),
+        figsize=(4, 4),
+    )
+
+    g = g_sns | g_p9
+
+    result_file = tmp_path / "g.png"
+    g.savefig(result_file)
     assert result_file.exists()


### PR DESCRIPTION
This PR adds a test which ensures that patchworklib is able to assemble figures using both seaborn and plotnine.