### PR TITLE
Create context managers for temporary plot9/seaborn patching

### DIFF
--- a/API.md
+++ b/API.md
@@ -28,6 +28,18 @@
 
   `None`
 
+- ### **`patched_axisgrid()`**
+
+  [Context manager](https://docs.python.org/3/reference/compound_stmts.html#with)/[decorator](https://docs.python.org/3/glossary.html#term-decorator)
+  interface for `overwrite_axisgrid` patching that reverts changes when leaving
+  `with`/function scope.
+
+  #### Returns
+
+  Context manager (i.e., `with patched_axisgrid():`) or decorator (i.e.,
+ `@patched_axisgrid()`) that temporarily patches seaborn for patchworklib
+  compatibility.
+
 - ### **`load_seabornobj(g, label=None, labels=None, figsize=(3, 3))`**
 
   Load a seaborn plot generated based on `seaborn._core.plot.Plotter` class. 

--- a/patchworklib/patchworklib.py
+++ b/patchworklib/patchworklib.py
@@ -664,7 +664,7 @@ def load_ggplot(ggplot=None, figsize=None):
 def patched_axisgrid():
     """
 
-    Temporarily patches seaborn.axisgrid methods with patchworklib counterparts.
+    Temporarily patch seaborn.axisgrid methods with patchworklib counterparts.
     This allows for custom behaviors in seaborn's grid objects like FacetGrid,
     PairGrid, JointGrid, and ClusterGrid, particularly useful when integrating
     seaborn's plotting with patchworklib's functionalities. Can be used as a

--- a/patchworklib/patchworklib.py
+++ b/patchworklib/patchworklib.py
@@ -228,17 +228,16 @@ def patched_plotnine():
     Examples
     -------
     >>> with patched_plotnine():
-    ...     # Example of using as a context manager
-    ...     pw.load_seabornobj(
-    ...         sns.jointplot(x="x", y="y", data=data),
+    ...     pw.load_ggplot(
+    ...         p9.ggplot(data, p9.aes(x="x", y="y", fill="fill")),
     ...     )
 
     Example use as a context manager.
 
     >>> @patched_plotnine()
     >>> def custom_plot():
-    ...     pw.load_seabornobj(
-    ...         sns.jointplot(x="x", y="y", data=data),
+    ...     pw.load_ggplot(
+    ...         p9.ggplot(data, p9.aes(x="x", y="y", fill="fill")),
     ...     )
     >>> custom_plot()
 

--- a/patchworklib/patchworklib.py
+++ b/patchworklib/patchworklib.py
@@ -687,11 +687,6 @@ def patched_axisgrid():
     >>> custom_plot()
 
     Example use as a decorator.
-
-    See Also
-    --------
-    patched_axisgrid : Context manager that applies then reverses axisgrid
-    patches.
     """
     # patch("sns.pairplot", mg.pairplot)
     with patch.object(
@@ -730,6 +725,10 @@ def overwrite_axisgrid():
     -------
     None.
     
+    See Also
+    --------
+    patched_axisgrid : Context manager that applies then reverses axisgrid
+    patches.
     """
     patched_axisgrid().__enter__()
 

--- a/tests/test_patchworklib.py
+++ b/tests/test_patchworklib.py
@@ -48,3 +48,46 @@ def test_sns_and_p9(tmp_path: Path):
     result_file = tmp_path / "g.png"
     g.savefig(result_file)
     assert result_file.exists()
+
+
+@pw.patched_axisgrid()
+def test_load_seabornobj(tmp_path: Path):
+    iris = sns.load_dataset("iris")
+    tips = sns.load_dataset("tips")
+
+    # An lmplot
+    g0 = sns.lmplot(
+        x="total_bill", y="tip", hue="smoker", data=tips, palette=dict(Yes="g", No="m")
+    )
+    g0 = pw.load_seaborngrid(g0, label="g0")
+
+    # A Pairplot
+    g1 = sns.pairplot(iris, hue="species")
+    g1 = pw.load_seaborngrid(g1, label="g1", figsize=(6, 6))
+
+    # A relplot
+    g2 = sns.relplot(
+        data=tips,
+        x="total_bill",
+        y="tip",
+        col="time",
+        hue="time",
+        size="size",
+        style="sex",
+        palette=["b", "r"],
+        sizes=(10, 100),
+    )
+    g2.set_titles("")
+    g2 = pw.load_seaborngrid(g2, label="g2")
+
+    # A JointGrid
+    g3 = sns.jointplot(
+        data=iris, x="sepal_width", y="petal_length", kind="kde", space=0
+    )
+    g3 = pw.load_seaborngrid(g3, label="g3")
+
+    composite = (((g0/g3)["g0"]|g1)["g1"]/g2).savefig()
+
+    result_file = tmp_path / "composite.png"
+    composite.savefig(result_file)
+    assert result_file.exists()

--- a/tests/test_patchworklib.py
+++ b/tests/test_patchworklib.py
@@ -100,3 +100,11 @@ def test_patched_axisgrid():
 
     assert not hasattr(sns.axisgrid.Grid, "_figure")
     assert sns.axisgrid.FacetGrid.add_legend is not pw.modified_grid.add_legend
+
+
+def test_patched_plotnine():
+    with pw.patched_plotnine():
+        if pw.patchworklib._needs_plotnine_ggplot_draw_patch:
+            assert p9.ggplot.draw is pw.modified_plotnine.draw
+
+    assert p9.ggplot.draw is not pw.modified_plotnine.draw

--- a/tests/test_patchworklib.py
+++ b/tests/test_patchworklib.py
@@ -51,7 +51,7 @@ def test_sns_and_p9(tmp_path: Path):
 
 
 @pw.patched_axisgrid()
-def test_load_seabornobj(tmp_path: Path):
+def _make_seabornobj():
     iris = sns.load_dataset("iris")
     tips = sns.load_dataset("tips")
 
@@ -87,6 +87,20 @@ def test_load_seabornobj(tmp_path: Path):
     g3 = pw.load_seaborngrid(g3, label="g3")
 
     composite = (((g0/g3)["g0"]|g1)["g1"]/g2)
+    return composite
+
+
+def test_load_seabornobj(tmp_path: Path):
+    composite = _make_seabornobj()
+
+    result_file = tmp_path / "composite.png"
+    composite.savefig(result_file)
+    assert result_file.exists()
+
+
+@pw.patched_axisgrid()  # duplicate patch wrapper
+def test_patch_nesting(tmp_path: Path):
+    composite = _make_seabornobj()
 
     result_file = tmp_path / "composite.png"
     composite.savefig(result_file)

--- a/tests/test_patchworklib.py
+++ b/tests/test_patchworklib.py
@@ -91,3 +91,12 @@ def test_load_seabornobj(tmp_path: Path):
     result_file = tmp_path / "composite.png"
     composite.savefig(result_file)
     assert result_file.exists()
+
+
+def test_patched_axisgrid():
+    with pw.patched_axisgrid():
+        assert hasattr(sns.axisgrid.Grid, "_figure")
+        assert sns.axisgrid.FacetGrid.add_legend is pw.modified_grid.add_legend
+
+    assert not hasattr(sns.axisgrid.Grid, "_figure")
+    assert sns.axisgrid.FacetGrid.add_legend is not pw.modified_grid.add_legend

--- a/tests/test_patchworklib.py
+++ b/tests/test_patchworklib.py
@@ -86,7 +86,7 @@ def test_load_seabornobj(tmp_path: Path):
     )
     g3 = pw.load_seaborngrid(g3, label="g3")
 
-    composite = (((g0/g3)["g0"]|g1)["g1"]/g2).savefig()
+    composite = (((g0/g3)["g0"]|g1)["g1"]/g2)
 
     result_file = tmp_path / "composite.png"
     composite.savefig(result_file)


### PR DESCRIPTION
Hi @ponnhide!

This pull request creates `patched_axisgrid` and `patched_plotnine`, both of which can serve either as a context manager or a function decorator to undo patchworklib's changes on seaborn and plotnine when leaving `with` context or function scope.
This will allow for better runtime interoperation of patchworklib with other code that may depend on the original seaborn/plotnine behavior.

Thanks for the useful library. I'm really glad to have figure-stitching capability available in Python and looking forward to seeing the library continue to develop.